### PR TITLE
IBX-1589: Renamed Extension ezdesign to ibexa_design_engine

### DIFF
--- a/src/bundle/DependencyInjection/Configuration.php
+++ b/src/bundle/DependencyInjection/Configuration.php
@@ -16,7 +16,7 @@ class Configuration extends SiteAccessConfiguration
 {
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder('ezdesign');
+        $treeBuilder = new TreeBuilder(IbexaDesignEngineExtension::EXTENSION_NAME);
 
         $rootNode = $treeBuilder->getRootNode();
         $rootNode

--- a/src/bundle/DependencyInjection/IbexaDesignEngineExtension.php
+++ b/src/bundle/DependencyInjection/IbexaDesignEngineExtension.php
@@ -17,9 +17,11 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class IbexaDesignEngineExtension extends Extension
 {
+    public const EXTENSION_NAME = 'ibexa_design_engine';
+
     public function getAlias()
     {
-        return 'ezdesign';
+        return self::EXTENSION_NAME;
     }
 
     public function getConfiguration(array $config, ContainerBuilder $container)


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1589](https://issues.ibexa.co/browse/IBX-1589)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | yes, requires ibexa/compatibility-layer#5

- [x] IBX-1589: Renamed Extension ezdesign to ibexa_design_engine

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- ~Provided automated test coverage.~ // full stack Behat coverage
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review
