### PR TITLE
[Composer] Rebranded authors section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
             "email": "jerome@vieilledent.fr"
         },
         {
-            "name": "eZ Systems dev team",
-            "email": "dev-team@ez.no"
+            "name": "Ibexa Engineering & Community",
+            "homepage": "https://www.ibexa.co/products"
         }
     ],
     "require": {


### PR DESCRIPTION
Rebranded `composer.authors` section to refer to Ibexa.