### PR TITLE
IBX-8139: Dropped class_alias BC layer statements from all classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,17 +39,13 @@
         "psr-4": {
             "Ibexa\\DesignEngine\\": "src/lib/",
             "Ibexa\\Bundle\\DesignEngine\\": "src/bundle/",
-            "Ibexa\\Contracts\\DesignEngine\\": "src/contracts/",
-            "EzSystems\\EzPlatformDesignEngine\\": "src/lib/",
-            "EzSystems\\EzPlatformDesignEngineBundle\\": "src/bundle/"
+            "Ibexa\\Contracts\\DesignEngine\\": "src/contracts/"
         }
     },
     "autoload-dev": {
         "psr-4": {
             "Ibexa\\Tests\\Bundle\\DesignEngine\\": "tests/bundle/",
-            "Ibexa\\Tests\\DesignEngine\\": "tests/lib/",
-            "EzSystems\\EzPlatformDesignEngine\\Tests\\": "tests/lib",
-            "EzSystems\\EzPlatformDesignEngineBundle\\Tests\\": "tests/bundle"
+            "Ibexa\\Tests\\DesignEngine\\": "tests/lib/"
         }
     },
     "scripts": {

--- a/src/bundle/DataCollector/TwigDataCollector.php
+++ b/src/bundle/DataCollector/TwigDataCollector.php
@@ -91,5 +91,3 @@ class TwigDataCollector extends BaseCollector implements LateDataCollectorInterf
         return $profile;
     }
 }
-
-class_alias(TwigDataCollector::class, 'EzSystems\EzPlatformDesignEngineBundle\DataCollector\TwigDataCollector');

--- a/src/bundle/DependencyInjection/Compiler/AssetPathResolutionPass.php
+++ b/src/bundle/DependencyInjection/Compiler/AssetPathResolutionPass.php
@@ -49,5 +49,3 @@ class AssetPathResolutionPass implements CompilerPassInterface
         return $resolvedPathsByDesign;
     }
 }
-
-class_alias(AssetPathResolutionPass::class, 'EzSystems\EzPlatformDesignEngineBundle\DependencyInjection\Compiler\AssetPathResolutionPass');

--- a/src/bundle/DependencyInjection/Compiler/AssetThemePass.php
+++ b/src/bundle/DependencyInjection/Compiler/AssetThemePass.php
@@ -91,5 +91,3 @@ class AssetThemePass implements CompilerPassInterface
             ->addMethodCall('addPackage', [DesignAwareInterface::DESIGN_NAMESPACE, $container->findDefinition(ThemePackage::class)]);
     }
 }
-
-class_alias(AssetThemePass::class, 'EzSystems\EzPlatformDesignEngineBundle\DependencyInjection\Compiler\AssetThemePass');

--- a/src/bundle/DependencyInjection/Compiler/TwigThemePass.php
+++ b/src/bundle/DependencyInjection/Compiler/TwigThemePass.php
@@ -108,5 +108,3 @@ class TwigThemePass implements CompilerPassInterface
         $twigDataCollector->addArgument(new Reference(TemplatePathRegistry::class));
     }
 }
-
-class_alias(TwigThemePass::class, 'EzSystems\EzPlatformDesignEngineBundle\DependencyInjection\Compiler\TwigThemePass');

--- a/src/bundle/DependencyInjection/Configuration.php
+++ b/src/bundle/DependencyInjection/Configuration.php
@@ -49,5 +49,3 @@ class Configuration extends SiteAccessConfiguration
         return $treeBuilder;
     }
 }
-
-class_alias(Configuration::class, 'EzSystems\EzPlatformDesignEngineBundle\DependencyInjection\Configuration');

--- a/src/bundle/DependencyInjection/DesignConfigParser.php
+++ b/src/bundle/DependencyInjection/DesignConfigParser.php
@@ -37,5 +37,3 @@ class DesignConfigParser implements ParserInterface
             ->end();
     }
 }
-
-class_alias(DesignConfigParser::class, 'EzSystems\EzPlatformDesignEngineBundle\DependencyInjection\DesignConfigParser');

--- a/src/bundle/DependencyInjection/IbexaDesignEngineExtension.php
+++ b/src/bundle/DependencyInjection/IbexaDesignEngineExtension.php
@@ -50,5 +50,3 @@ class IbexaDesignEngineExtension extends Extension
         $container->setParameter('ibexa.design.assets.resolution.disabled', $config['disable_assets_pre_resolution']);
     }
 }
-
-class_alias(IbexaDesignEngineExtension::class, 'EzSystems\EzPlatformDesignEngineBundle\DependencyInjection\EzPlatformDesignEngineExtension');

--- a/src/bundle/IbexaDesignEngineBundle.php
+++ b/src/bundle/IbexaDesignEngineBundle.php
@@ -41,5 +41,3 @@ class IbexaDesignEngineBundle extends Bundle
         return $this->extension;
     }
 }
-
-class_alias(IbexaDesignEngineBundle::class, 'EzSystems\EzPlatformDesignEngineBundle\EzPlatformDesignEngineBundle');

--- a/src/contracts/DesignAwareInterface.php
+++ b/src/contracts/DesignAwareInterface.php
@@ -13,5 +13,3 @@ interface DesignAwareInterface
 
     public function getCurrentDesign(): ?string;
 }
-
-class_alias(DesignAwareInterface::class, 'EzSystems\EzPlatformDesignEngine\DesignAwareInterface');

--- a/src/lib/Asset/AssetPathProvisionerInterface.php
+++ b/src/lib/Asset/AssetPathProvisionerInterface.php
@@ -20,5 +20,3 @@ interface AssetPathProvisionerInterface
      */
     public function provisionResolvedPaths(array $assetsPaths, $design);
 }
-
-class_alias(AssetPathProvisionerInterface::class, 'EzSystems\EzPlatformDesignEngine\Asset\AssetPathProvisionerInterface');

--- a/src/lib/Asset/AssetPathResolver.php
+++ b/src/lib/Asset/AssetPathResolver.php
@@ -58,5 +58,3 @@ class AssetPathResolver implements AssetPathResolverInterface
         return $path;
     }
 }
-
-class_alias(AssetPathResolver::class, 'EzSystems\EzPlatformDesignEngine\Asset\AssetPathResolver');

--- a/src/lib/Asset/AssetPathResolverInterface.php
+++ b/src/lib/Asset/AssetPathResolverInterface.php
@@ -23,5 +23,3 @@ interface AssetPathResolverInterface
      */
     public function resolveAssetPath($path, $design);
 }
-
-class_alias(AssetPathResolverInterface::class, 'EzSystems\EzPlatformDesignEngine\Asset\AssetPathResolverInterface');

--- a/src/lib/Asset/ProvisionedPathResolver.php
+++ b/src/lib/Asset/ProvisionedPathResolver.php
@@ -91,5 +91,3 @@ class ProvisionedPathResolver implements AssetPathResolverInterface, AssetPathPr
         return $logicalPaths;
     }
 }
-
-class_alias(ProvisionedPathResolver::class, 'EzSystems\EzPlatformDesignEngine\Asset\ProvisionedPathResolver');

--- a/src/lib/Asset/ThemePackage.php
+++ b/src/lib/Asset/ThemePackage.php
@@ -41,5 +41,3 @@ class ThemePackage implements PackageInterface, DesignAwareInterface
         return $this->innerPackage->getVersion($this->pathResolver->resolveAssetPath($path, $this->getCurrentDesign()));
     }
 }
-
-class_alias(ThemePackage::class, 'EzSystems\EzPlatformDesignEngine\Asset\ThemePackage');

--- a/src/lib/DesignAwareTrait.php
+++ b/src/lib/DesignAwareTrait.php
@@ -26,5 +26,3 @@ trait DesignAwareTrait
         return $this->configResolver->getParameter('design');
     }
 }
-
-class_alias(DesignAwareTrait::class, 'EzSystems\EzPlatformDesignEngine\DesignAwareTrait');

--- a/src/lib/Exception/InvalidDesignException.php
+++ b/src/lib/Exception/InvalidDesignException.php
@@ -12,5 +12,3 @@ use InvalidArgumentException;
 class InvalidDesignException extends InvalidArgumentException
 {
 }
-
-class_alias(InvalidDesignException::class, 'EzSystems\EzPlatformDesignEngine\Exception\InvalidDesignException');

--- a/src/lib/Templating/TemplateNameResolverInterface.php
+++ b/src/lib/Templating/TemplateNameResolverInterface.php
@@ -39,5 +39,3 @@ interface TemplateNameResolverInterface extends DesignAwareInterface
      */
     public function isTemplateDesignNamespaced($name);
 }
-
-class_alias(TemplateNameResolverInterface::class, 'EzSystems\EzPlatformDesignEngine\Templating\TemplateNameResolverInterface');

--- a/src/lib/Templating/TemplatePathRegistry.php
+++ b/src/lib/Templating/TemplatePathRegistry.php
@@ -57,5 +57,3 @@ class TemplatePathRegistry implements TemplatePathRegistryInterface, Serializabl
         [$this->pathMap, $this->kernelRootDir] = $data;
     }
 }
-
-class_alias(TemplatePathRegistry::class, 'EzSystems\EzPlatformDesignEngine\Templating\TemplatePathRegistry');

--- a/src/lib/Templating/TemplatePathRegistryInterface.php
+++ b/src/lib/Templating/TemplatePathRegistryInterface.php
@@ -37,5 +37,3 @@ interface TemplatePathRegistryInterface
      */
     public function getPathMap();
 }
-
-class_alias(TemplatePathRegistryInterface::class, 'EzSystems\EzPlatformDesignEngine\Templating\TemplatePathRegistryInterface');

--- a/src/lib/Templating/ThemeTemplateNameResolver.php
+++ b/src/lib/Templating/ThemeTemplateNameResolver.php
@@ -44,5 +44,3 @@ class ThemeTemplateNameResolver implements TemplateNameResolverInterface
         return (strpos($name, '@' . static::DESIGN_NAMESPACE) !== false) || (strpos($name, '@' . $this->getCurrentDesign()) !== false);
     }
 }
-
-class_alias(ThemeTemplateNameResolver::class, 'EzSystems\EzPlatformDesignEngine\Templating\ThemeTemplateNameResolver');

--- a/src/lib/Templating/Twig/TwigThemeLoader.php
+++ b/src/lib/Templating/Twig/TwigThemeLoader.php
@@ -97,5 +97,3 @@ class TwigThemeLoader implements LoaderInterface
         $this->innerFilesystemLoader->prependPath($path, $namespace);
     }
 }
-
-class_alias(TwigThemeLoader::class, 'EzSystems\EzPlatformDesignEngine\Templating\Twig\TwigThemeLoader');

--- a/tests/lib/Asset/AssetPathResolverTest.php
+++ b/tests/lib/Asset/AssetPathResolverTest.php
@@ -132,5 +132,3 @@ class AssetPathResolverTest extends TestCase
         self::assertSame($resolvedPath, $resolver->resolveAssetPath($path, 'foo'));
     }
 }
-
-class_alias(AssetPathResolverTest::class, 'EzSystems\EzPlatformDesignEngine\Tests\Asset\AssetPathResolverTest');

--- a/tests/lib/Asset/ProvisionedPathResolverTest.php
+++ b/tests/lib/Asset/ProvisionedPathResolverTest.php
@@ -112,5 +112,3 @@ class ProvisionedPathResolverTest extends TestCase
         self::assertEquals($expectedResolvedPaths, $provisioner->provisionResolvedPaths($themesPaths, $design));
     }
 }
-
-class_alias(ProvisionedPathResolverTest::class, 'EzSystems\EzPlatformDesignEngine\Tests\Asset\ProvisionedPathResolverTest');

--- a/tests/lib/Asset/ThemePackageTest.php
+++ b/tests/lib/Asset/ThemePackageTest.php
@@ -92,5 +92,3 @@ class ThemePackageTest extends TestCase
         self::assertSame($version, $package->getVersion($assetPath));
     }
 }
-
-class_alias(ThemePackageTest::class, 'EzSystems\EzPlatformDesignEngine\Tests\Asset\ThemePackageTest');

--- a/tests/lib/Templating/TemplatePathRegistryTest.php
+++ b/tests/lib/Templating/TemplatePathRegistryTest.php
@@ -55,5 +55,3 @@ class TemplatePathRegistryTest extends TestCase
         self::assertSame($templateLogicalName, $registry->getTemplatePath($templateLogicalName));
     }
 }
-
-class_alias(TemplatePathRegistryTest::class, 'EzSystems\EzPlatformDesignEngine\Tests\Templating\TemplatePathRegistryTest');

--- a/tests/lib/Templating/ThemeTemplateNameResolverTest.php
+++ b/tests/lib/Templating/ThemeTemplateNameResolverTest.php
@@ -70,5 +70,3 @@ class ThemeTemplateNameResolverTest extends TestCase
         self::assertSame($expected, $resolver->isTemplateDesignNamespaced($templateName));
     }
 }
-
-class_alias(ThemeTemplateNameResolverTest::class, 'EzSystems\EzPlatformDesignEngine\Tests\Templating\ThemeTemplateNameResolverTest');


### PR DESCRIPTION
| :ticket: Issue | IBX-8139 |
|----------------|-----------|

#### Description:

Dropped `class_alias` BC layer statements from all classes using https://github.com/ibexa/rector/pull/2

#### For QA:

No QA needed

#### Documentation:

Document that our BC layer has been dropped
