### PR TITLE
IBX-9727: Added missing type hints

### DIFF
--- a/src/lib/Asset/AssetPathResolver.php
+++ b/src/lib/Asset/AssetPathResolver.php
@@ -19,7 +19,7 @@ class AssetPathResolver implements AssetPathResolverInterface
 
     private ?LoggerInterface $logger;
 
-    public function __construct(array $designPaths, $webRootDir, LoggerInterface $logger = null)
+    public function __construct(array $designPaths, string $webRootDir, LoggerInterface $logger = null)
     {
         $this->designPaths = $designPaths;
         $this->webRootDir = $webRootDir;

--- a/src/lib/Asset/ProvisionedPathResolver.php
+++ b/src/lib/Asset/ProvisionedPathResolver.php
@@ -20,7 +20,7 @@ class ProvisionedPathResolver implements AssetPathResolverInterface, AssetPathPr
 
     private string $webRootDir;
 
-    public function __construct(array $resolvedPaths, AssetPathResolverInterface $innerResolver, $webRootDir)
+    public function __construct(array $resolvedPaths, AssetPathResolverInterface $innerResolver, string $webRootDir)
     {
         $this->resolvedPaths = $resolvedPaths;
         $this->innerResolver = $innerResolver;

--- a/src/lib/Templating/TemplatePathRegistry.php
+++ b/src/lib/Templating/TemplatePathRegistry.php
@@ -16,7 +16,7 @@ class TemplatePathRegistry implements TemplatePathRegistryInterface, Serializabl
 
     private string $kernelRootDir;
 
-    public function __construct($kernelRootDir)
+    public function __construct(string $kernelRootDir)
     {
         $this->kernelRootDir = $kernelRootDir;
     }

--- a/src/lib/Templating/Twig/TwigThemeLoader.php
+++ b/src/lib/Templating/Twig/TwigThemeLoader.php
@@ -77,7 +77,7 @@ class TwigThemeLoader implements LoaderInterface
     /**
      * @param string|string[] $paths
      */
-    public function setPaths(string|array $paths, $namespace = FilesystemLoader::MAIN_NAMESPACE): void
+    public function setPaths(string|array $paths, string $namespace = FilesystemLoader::MAIN_NAMESPACE): void
     {
         $this->innerFilesystemLoader->setPaths($paths, $namespace);
     }

--- a/tests/lib/Asset/AssetPathResolverTest.php
+++ b/tests/lib/Asset/AssetPathResolverTest.php
@@ -15,7 +15,7 @@ use Psr\Log\LoggerInterface;
 
 class AssetPathResolverTest extends TestCase
 {
-    public function testResolveAssetPathFail()
+    public function testResolveAssetPathFail(): void
     {
         $logger = $this->createMock(LoggerInterface::class);
         $logger
@@ -30,7 +30,7 @@ class AssetPathResolverTest extends TestCase
     /**
      * @covers \Ibexa\DesignEngine\Asset\AssetPathResolver::resolveAssetPath
      */
-    public function testResolveInvalidDesign()
+    public function testResolveInvalidDesign(): void
     {
         $resolver = new AssetPathResolver([], __DIR__);
         $assetPath = 'images/foo.png';
@@ -38,7 +38,7 @@ class AssetPathResolverTest extends TestCase
         self::assertSame($assetPath, $resolver->resolveAssetPath($assetPath, 'foo'));
     }
 
-    public function resolveAssetPathProvider()
+    public function resolveAssetPathProvider(): array
     {
         return [
             [
@@ -107,7 +107,7 @@ class AssetPathResolverTest extends TestCase
     /**
      * @dataProvider resolveAssetPathProvider
      */
-    public function testResolveAssetPath(array $designPaths, array $existingPaths, $path, $resolvedPath)
+    public function testResolveAssetPath(array $designPaths, array $existingPaths, string $path, string $resolvedPath): void
     {
         $webrootDir = vfsStream::setup('web');
         foreach ($designPaths['foo'] as $designPath) {

--- a/tests/lib/Asset/ProvisionedPathResolverTest.php
+++ b/tests/lib/Asset/ProvisionedPathResolverTest.php
@@ -16,10 +16,7 @@ use PHPUnit\Framework\TestCase;
 
 class ProvisionedPathResolverTest extends TestCase
 {
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Ibexa\DesignEngine\Asset\AssetPathResolverInterface
-     */
-    private MockObject $innerResolver;
+    private AssetPathResolverInterface&MockObject $innerResolver;
 
     /**
      * @var \org\bovigo\vfs\vfsStreamDirectory

--- a/tests/lib/Asset/ProvisionedPathResolverTest.php
+++ b/tests/lib/Asset/ProvisionedPathResolverTest.php
@@ -11,6 +11,7 @@ use Ibexa\DesignEngine\Asset\AssetPathResolver;
 use Ibexa\DesignEngine\Asset\AssetPathResolverInterface;
 use Ibexa\DesignEngine\Asset\ProvisionedPathResolver;
 use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class ProvisionedPathResolverTest extends TestCase
@@ -18,7 +19,7 @@ class ProvisionedPathResolverTest extends TestCase
     /**
      * @var \PHPUnit\Framework\MockObject\MockObject|\Ibexa\DesignEngine\Asset\AssetPathResolverInterface
      */
-    private $innerResolver;
+    private MockObject $innerResolver;
 
     /**
      * @var \org\bovigo\vfs\vfsStreamDirectory
@@ -32,7 +33,7 @@ class ProvisionedPathResolverTest extends TestCase
         $this->webrootDir = vfsStream::setup('web');
     }
 
-    public function testResolvePathNotProvisioned()
+    public function testResolvePathNotProvisioned(): void
     {
         $assetLogicalPath = 'images/some_image.jpg';
         $design = 'foo';
@@ -51,7 +52,7 @@ class ProvisionedPathResolverTest extends TestCase
         self::assertSame($expected, $resolver->resolveAssetPath($assetLogicalPath, $design));
     }
 
-    public function testResolveProvisionedPath()
+    public function testResolveProvisionedPath(): void
     {
         $expected = 'some/path/images/some_image.jpg';
         $assetLogicalPath = 'images/some_image.jpg';
@@ -64,7 +65,7 @@ class ProvisionedPathResolverTest extends TestCase
         self::assertSame($expected, $resolver->resolveAssetPath($assetLogicalPath, $design));
     }
 
-    public function testProvisionResolvedPaths()
+    public function testProvisionResolvedPaths(): void
     {
         $design = 'some_design';
         $themesPaths = [

--- a/tests/lib/Asset/ThemePackageTest.php
+++ b/tests/lib/Asset/ThemePackageTest.php
@@ -16,20 +16,11 @@ use Symfony\Component\Asset\PackageInterface;
 
 class ThemePackageTest extends TestCase
 {
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Ibexa\DesignEngine\Asset\AssetPathResolverInterface
-     */
-    private MockObject $assetPathResolver;
+    private AssetPathResolverInterface&MockObject $assetPathResolver;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Symfony\Component\Asset\PackageInterface
-     */
-    private MockObject $innerPackage;
+    private PackageInterface&MockObject $innerPackage;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface
-     */
-    private MockObject $configResolver;
+    private ConfigResolverInterface&MockObject $configResolver;
 
     protected function setUp(): void
     {

--- a/tests/lib/Asset/ThemePackageTest.php
+++ b/tests/lib/Asset/ThemePackageTest.php
@@ -10,6 +10,7 @@ namespace Ibexa\Tests\DesignEngine\Asset;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\DesignEngine\Asset\AssetPathResolverInterface;
 use Ibexa\DesignEngine\Asset\ThemePackage;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Asset\PackageInterface;
 
@@ -18,17 +19,17 @@ class ThemePackageTest extends TestCase
     /**
      * @var \PHPUnit\Framework\MockObject\MockObject|\Ibexa\DesignEngine\Asset\AssetPathResolverInterface
      */
-    private $assetPathResolver;
+    private MockObject $assetPathResolver;
 
     /**
      * @var \PHPUnit\Framework\MockObject\MockObject|\Symfony\Component\Asset\PackageInterface
      */
-    private $innerPackage;
+    private MockObject $innerPackage;
 
     /**
      * @var \PHPUnit\Framework\MockObject\MockObject|\Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface
      */
-    private $configResolver;
+    private MockObject $configResolver;
 
     protected function setUp(): void
     {
@@ -39,7 +40,7 @@ class ThemePackageTest extends TestCase
         $this->configResolver = $this->createMock(ConfigResolverInterface::class);
     }
 
-    public function testGetUrl()
+    public function testGetUrl(): void
     {
         $assetPath = 'images/foo.png';
         $fullAssetPath = 'assets/' . $assetPath;
@@ -65,7 +66,7 @@ class ThemePackageTest extends TestCase
         self::assertSame("/$fullAssetPath", $package->getUrl($assetPath));
     }
 
-    public function testGetVersion()
+    public function testGetVersion(): void
     {
         $assetPath = 'images/foo.png';
         $fullAssetPath = 'assets/' . $assetPath;

--- a/tests/lib/Templating/TemplatePathRegistryTest.php
+++ b/tests/lib/Templating/TemplatePathRegistryTest.php
@@ -12,12 +12,12 @@ use PHPUnit\Framework\TestCase;
 
 class TemplatePathRegistryTest extends TestCase
 {
-    private function getExpectedRelativePath($templateFullPath, $kernelRootDir)
+    private function getExpectedRelativePath(string $templateFullPath, string $kernelRootDir): string
     {
         return str_replace($kernelRootDir . '/', '', $templateFullPath);
     }
 
-    public function testMapTemplatePath()
+    public function testMapTemplatePath(): void
     {
         $kernelRootDir = __DIR__;
         $templateLogicalName = '@foo/bar.html.twig';
@@ -32,7 +32,7 @@ class TemplatePathRegistryTest extends TestCase
         );
     }
 
-    public function testGetTemplatePath()
+    public function testGetTemplatePath(): void
     {
         $kernelRootDir = __DIR__;
         $templateLogicalName = '@foo/bar.html.twig';
@@ -46,7 +46,7 @@ class TemplatePathRegistryTest extends TestCase
         );
     }
 
-    public function testGetTemplatePathNotMapped()
+    public function testGetTemplatePathNotMapped(): void
     {
         $kernelRootDir = __DIR__;
         $templateLogicalName = '@foo/bar.html.twig';

--- a/tests/lib/Templating/ThemeTemplateNameResolverTest.php
+++ b/tests/lib/Templating/ThemeTemplateNameResolverTest.php
@@ -9,6 +9,7 @@ namespace Ibexa\Tests\DesignEngine\Templating;
 
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\DesignEngine\Templating\ThemeTemplateNameResolver;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class ThemeTemplateNameResolverTest extends TestCase
@@ -16,7 +17,7 @@ class ThemeTemplateNameResolverTest extends TestCase
     /**
      * @var \PHPUnit\Framework\MockObject\MockObject|\Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface
      */
-    private $configResolver;
+    private MockObject $configResolver;
 
     protected function setUp(): void
     {
@@ -25,7 +26,7 @@ class ThemeTemplateNameResolverTest extends TestCase
         $this->configResolver = $this->createMock(ConfigResolverInterface::class);
     }
 
-    public function templateNameProvider()
+    public function templateNameProvider(): array
     {
         return [
             [null, 'foo.html.twig', 'foo.html.twig'],
@@ -37,7 +38,7 @@ class ThemeTemplateNameResolverTest extends TestCase
     /**
      * @dataProvider templateNameProvider
      */
-    public function testResolveTemplateName($currentDesign, $templateName, $expectedTemplateName)
+    public function testResolveTemplateName(?string $currentDesign, string $templateName, string $expectedTemplateName): void
     {
         $this->configResolver
             ->method('getParameter')
@@ -47,7 +48,7 @@ class ThemeTemplateNameResolverTest extends TestCase
         self::assertSame($expectedTemplateName, $resolver->resolveTemplateName($templateName));
     }
 
-    public function isTemplateDesignNamespacedProvider()
+    public function isTemplateDesignNamespacedProvider(): array
     {
         return [
             [null, 'foo.html.twig', false],
@@ -60,7 +61,7 @@ class ThemeTemplateNameResolverTest extends TestCase
     /**
      * @dataProvider isTemplateDesignNamespacedProvider
      */
-    public function testIsTemplateDesignNamespaced($currentDesign, $templateName, $expected)
+    public function testIsTemplateDesignNamespaced(?string $currentDesign, string $templateName, bool $expected): void
     {
         $this->configResolver
             ->method('getParameter')

--- a/tests/lib/Templating/ThemeTemplateNameResolverTest.php
+++ b/tests/lib/Templating/ThemeTemplateNameResolverTest.php
@@ -14,10 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 class ThemeTemplateNameResolverTest extends TestCase
 {
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface
-     */
-    private MockObject $configResolver;
+    private ConfigResolverInterface&MockObject $configResolver;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
> [!CAUTION]
> These changes are volatile and - in some repositories - extensive, so they need to be carefully reviewed before merging.

| :ticket: Issue | IBX-9727 |
|----------------|-----------|

#### Description:

Added missing strict type hints using `\Rector\Set\ValueObject\SetList::TYPE_DECLARATION` set.
Additionally FQCNs have been imported for every affected file using PHP CS Fixer, in some cases they might override unrelated lines.

#### For QA:

Regression tests.
