### PR TITLE
IBX-10341: Fixed accessing templatePathRegistry property in TwigDataCollector::getTemplatePathRegistry

### DIFF
--- a/src/bundle/DataCollector/TwigDataCollector.php
+++ b/src/bundle/DataCollector/TwigDataCollector.php
@@ -17,14 +17,14 @@ class TwigDataCollector extends BaseCollector
     public function __construct(
         Profile $profile,
         Environment $environment,
-        private TemplatePathRegistryInterface $templatePathRegistry
+        private ?TemplatePathRegistryInterface $templatePathRegistry
     ) {
         parent::__construct($profile, $environment);
     }
 
     private function getTemplatePathRegistry(): TemplatePathRegistryInterface
     {
-        return $this->templatePathRegistry;
+        return $this->templatePathRegistry ??= unserialize($this->data['template_path_registry']);
     }
 
     #[\Override]


### PR DESCRIPTION
| :ticket: Issue | [IBX-10341](https://issues.ibexa.co/browse/IBX-10341) |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Fixes bug - accessing property before initialization introduced in https://github.com/ibexa/design-engine/pull/38

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
